### PR TITLE
Update bitwise-trie.asm

### DIFF
--- a/bitwise-trie.asm
+++ b/bitwise-trie.asm
@@ -387,7 +387,7 @@
 				syscall
 		vis_print_continue:
 			# imprimir string ", NT" ou ", T"
-			lw $t1, 8($t0)
+			lb $t1, 8($t0)
 			bnez $t1, vis_print_T
 			
 			vis_print_NT:


### PR DESCRIPTION
* Visualização agora da um load byte na flag de T (terminal) e NT (não terminal) ao invés de um load word